### PR TITLE
bugfix: fixed phony parameter in scanForDevice in the VL6180XScanner class

### DIFF
--- a/Code/LibDemoArduinoToF/LibDemoArduinoToF.ino
+++ b/Code/LibDemoArduinoToF/LibDemoArduinoToF.ino
@@ -63,8 +63,8 @@ public:
     : WireScanner(wire, label) {}
 
   // Override scanForDevice to only look for the VL6180X address
-  bool scanForDevice(byte address) override {
-    return address == VL6180X::DEFAULT_SENSOR_ADDRESS && WireScanner::scanForDevice(address);
+  bool scanForDevice() override {
+    return WireScanner::scanForDevice(VL6180X::DEFAULT_SENSOR_ADDRESS);
   }
 };
 


### PR DESCRIPTION
fixed phony parameter in the scanForDevice function.
This parameter made it look like the address to scan for could be chosen while returning false from the function if it wasn't the default address of the VL6180X ToF ic. 

The check for the default address has been removed as well as the parameter. 
The scan now always checks for the default address and returns true if  a device with that address is on the i2c bus.